### PR TITLE
Add settings menu with temperature unit toggle

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -4,6 +4,7 @@ import SwiftUI
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItemController: StatusItemController?
     var bluetoothManager: BluetoothManager?
+    var settingsManager: SettingsManager?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         print("App launched!")
@@ -12,11 +13,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Hide from Dock
         NSApp.setActivationPolicy(.accessory)
 
-        // Initialize Bluetooth manager
+        // Initialize managers
         bluetoothManager = BluetoothManager()
+        settingsManager = SettingsManager()
 
         // Initialize status item controller
-        statusItemController = StatusItemController(bluetoothManager: bluetoothManager!)
+        statusItemController = StatusItemController(bluetoothManager: bluetoothManager!, settingsManager: settingsManager!)
 
         print("Status item created")
         NSLog("Status item created")

--- a/Aranet4Data.swift
+++ b/Aranet4Data.swift
@@ -65,8 +65,10 @@ struct Aranet4Reading {
     }
 
     // Format for menu bar display
-    var menuBarText: String {
-        return "CO2: \(co2) T: \(String(format: "%.1f", temperature))°C"
+    func menuBarText(unit: TemperatureUnit) -> String {
+        let tempValue = unit == .fahrenheit ? (temperature * 9/5 + 32) : temperature
+        let unitSymbol = unit == .fahrenheit ? "F" : "C"
+        return "CO2: \(co2) T: \(String(format: "%.1f", tempValue))°\(unitSymbol)"
     }
 
     // Get CO2 level status

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 - [ ] Export data to CSV
 - [ ] Custom alert thresholds
 - [ ] Menu bar icon customization
-- [ ] Temperature unit preference (°C/°F)
+- [x] Temperature unit preference (°C/°F)
 
 ## Acknowledgments
 

--- a/SettingsManager.swift
+++ b/SettingsManager.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Combine
+
+enum TemperatureUnit: String, CaseIterable {
+    case celsius = "C"
+    case fahrenheit = "F"
+}
+
+class SettingsManager: ObservableObject {
+    private static let temperatureUnitKey = "temperatureUnit"
+
+    @Published var temperatureUnit: TemperatureUnit {
+        didSet {
+            UserDefaults.standard.set(temperatureUnit.rawValue, forKey: Self.temperatureUnitKey)
+        }
+    }
+
+    init() {
+        if let savedValue = UserDefaults.standard.string(forKey: Self.temperatureUnitKey),
+           let unit = TemperatureUnit(rawValue: savedValue) {
+            self.temperatureUnit = unit
+        } else {
+            self.temperatureUnit = .celsius
+        }
+    }
+
+    func formatTemperature(_ celsius: Double) -> String {
+        switch temperatureUnit {
+        case .celsius:
+            return String(format: "%.1f°C", celsius)
+        case .fahrenheit:
+            let fahrenheit = celsius * 9/5 + 32
+            return String(format: "%.1f°F", fahrenheit)
+        }
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ swiftc \
     -framework Combine \
     Aranet4Data.swift \
     BluetoothManager.swift \
+    SettingsManager.swift \
     StatusItemController.swift \
     MenuBarView.swift \
     AppDelegate.swift \


### PR DESCRIPTION
## Summary
- Add a Settings view accessible via gear icon in the popup panel header
- First setting allows toggling between Celsius (°C) and Fahrenheit (°F) for temperature display
- Preference persists across app restarts using UserDefaults
- Both menu bar title and panel display update reactively when the setting changes
